### PR TITLE
fix: add GitHub authentication for private Articles repository

### DIFF
--- a/scripts/fetch-article-og-images.js
+++ b/scripts/fetch-article-og-images.js
@@ -35,12 +35,17 @@ const OG_IMAGES_DIR = path.join(process.cwd(), 'public', 'og-images');
 async function fetchOGImagesList() {
   const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/images/og-images?ref=${GITHUB_BRANCH}`;
 
-  const response = await fetch(url, {
-    headers: {
-      'User-Agent': 'Notiography-Build-Script',
-      'Accept': 'application/vnd.github.v3+json',
-    },
-  });
+  const headers = {
+    'User-Agent': 'Notiography-Build-Script',
+    'Accept': 'application/vnd.github.v3+json',
+  };
+
+  // プライベートリポジトリの場合は認証トークンが必要
+  if (process.env.GITHUB_TOKEN) {
+    headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const response = await fetch(url, { headers });
 
   if (!response.ok) {
     if (response.status === 404) {

--- a/scripts/fetch-cover-images.js
+++ b/scripts/fetch-cover-images.js
@@ -36,12 +36,17 @@ const COVERS_DIR = path.join(process.cwd(), 'public', 'images', 'covers');
 async function fetchCoverImagesList() {
   const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/images/covers?ref=${GITHUB_BRANCH}`;
 
-  const response = await fetch(url, {
-    headers: {
-      'User-Agent': 'Notiography-Build-Script',
-      'Accept': 'application/vnd.github.v3+json',
-    },
-  });
+  const headers = {
+    'User-Agent': 'Notiography-Build-Script',
+    'Accept': 'application/vnd.github.v3+json',
+  };
+
+  // プライベートリポジトリの場合は認証トークンが必要
+  if (process.env.GITHUB_TOKEN) {
+    headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const response = await fetch(url, { headers });
 
   if (!response.ok) {
     if (response.status === 404) {


### PR DESCRIPTION
## 概要

Articlesリポジトリからカバー画像とOG画像を取得する際に、GitHub認証を使用するように修正しました。

## 背景

Articlesリポジトリはプライベートリポジトリですが、画像取得スクリプト（`fetch-cover-images.js`と`fetch-article-og-images.js`）がGitHub API呼び出し時に認証を行っていませんでした。そのため、Netlifyビルド時にAPI呼び出しが404エラーで失敗し、画像が取得できない状態になっていました。

## 変更内容

- `scripts/fetch-cover-images.js`: GitHub API呼び出しに`GITHUB_TOKEN`認証を追加
- `scripts/fetch-article-og-images.js`: GitHub API呼び出しに`GITHUB_TOKEN`認証を追加

両スクリプトとも、環境変数`GITHUB_TOKEN`が設定されている場合は`Authorization`ヘッダーを追加するようにしました。

## 必要な対応

マージ後、Netlifyの環境変数に以下を設定してください：

- **変数名**: `GITHUB_TOKEN`
- **値**: プライベートリポジトリにアクセスできるGitHub Personal Access Token
- **必要な権限**: `repo` (プライベートリポジトリの読み取りアクセス)

### GitHub Personal Access Tokenの作成方法

1. GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
2. "Generate new token" をクリック
3. `repo` スコープを選択
4. 生成されたトークンをNetlifyの環境変数に設定

## テスト計画

- [ ] Netlifyに`GITHUB_TOKEN`環境変数を設定
- [ ] デプロイを実行して、カバー画像とOG画像が正しく取得されることを確認
- [ ] ビルドログに「⚠️  images/covers ディレクトリが見つかりません」エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub authentication tokens, enabling access to content from private repositories while maintaining compatibility with public repositories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->