### PR TITLE
feat: auto-sync preview branch with main

### DIFF
--- a/.github/workflows/sync-preview-branch.yml
+++ b/.github/workflows/sync-preview-branch.yml
@@ -1,0 +1,37 @@
+name: Sync Preview Branch
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync preview branch with main
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          # previewブランチをチェックアウト
+          git fetch origin preview:preview || git checkout -b preview
+          git checkout preview
+
+          # mainからマージ
+          git merge origin/main -m "chore: sync preview with main
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+          Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+
+          # プッシュ
+          git push origin preview


### PR DESCRIPTION
## 概要

mainブランチが更新されたら自動的にpreviewブランチも同期されるようにGitHub Actionsワークフローを追加しました。

## 背景

現在、プレビューデプロイ用の`preview`ブランチは手動で`main`と同期する必要があります。これにより、`main`ブランチの最新の修正（画像パスの変更、認証追加など）がプレビュー環境に反映されないことがありました。

## 変更内容

新しいGitHub Actionsワークフロー `.github/workflows/sync-preview-branch.yml` を追加：

- **トリガー**: `main`ブランチへのpush
- **処理**: 
  1. リポジトリをチェックアウト
  2. `preview`ブランチをチェックアウト（存在しない場合は作成）
  3. `main`ブランチの変更を`preview`にマージ
  4. `preview`ブランチをpush

## 効果

- プレビューデプロイが常に最新のコードを使用
- 手動での同期作業が不要に
- `main`と`preview`の差分を気にする必要がなくなる

## テスト計画

- [ ] このPRをマージ
- [ ] mainに別のコミットをpush
- [ ] GitHub Actionsが自動実行されpreviewブランチが更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development infrastructure with automated synchronization of release branches to improve deployment efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->